### PR TITLE
docs: add contribution guide

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,22 @@
+# Contribution Guide
+
+## Code Style
+- Target Python **3.11+**.
+- Follow `ruff` with a line length of **100**.
+
+## Required Checks
+Run the following commands before committing:
+
+```bash
+ruff check
+ruff format --check
+pytest -q
+```
+
+## Commit Conventions
+- Use concise, imperative commit messages (e.g., `feat: add feature`).
+- Each commit should represent a logical change.
+
+## Cross-Platform Support
+- Ensure all scripts and tests run on Linux, macOS, and Windows.
+- Executables are built using **PyInstaller**.

--- a/smart-pdf-md.sh
+++ b/smart-pdf-md.sh
@@ -51,11 +51,7 @@ if ! command -v python >/dev/null 2>&1; then echo "[FATAL] Python not found on P
 if ! python -m pip --version >/dev/null 2>&1; then echo "[FATAL] pip not available"; exit 1; fi
 
 echo "[deps] Checking PyMuPDF..."
-if ! python - <<'PY' >/dev/null 2>&1; then
-import importlib.util,sys
-sys.exit(0 if importlib.util.find_spec('fitz') else 1)
-PY
-then
+if ! python -c "import importlib.util,sys; sys.exit(0 if importlib.util.find_spec('fitz') else 1)" >/dev/null 2>&1; then
   echo "[deps] Installing PyMuPDF ..."
   python -m pip install -q pymupdf || { echo "[FATAL] pip install pymupdf failed"; exit 1; }
 else
@@ -64,11 +60,7 @@ fi
 
 if [[ "${MODE,,}" != "fast" ]]; then
   echo "[deps] Checking marker-pdf..."
-  if ! python - <<'PY' >/dev/null 2>&1; then
-import importlib.util,sys
-sys.exit(0 if importlib.util.find_spec('marker') else 1)
-PY
-  then
+  if ! python -c "import importlib.util,sys; sys.exit(0 if importlib.util.find_spec('marker') else 1)" >/dev/null 2>&1; then
     echo "[deps] Installing marker-pdf ..."
     python -m pip install -q marker-pdf || { echo "[FATAL] pip install marker-pdf failed"; exit 1; }
   else

--- a/tests/test_backoff_and_cli.py
+++ b/tests/test_backoff_and_cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 def ensure_pymupdf():
     try:
         import importlib.util  # noqa: F401
+
         if importlib.util.find_spec("fitz") is None:
             raise ImportError
     except Exception:
@@ -44,7 +45,9 @@ def test_cli_flags_mode_out_and_images(tmp_path: Path):
     outdir = tmp_path / "cli-out"
     make_blank_pdf(pdf)
     # Force marker path with mock using CLI flags only
-    res = run_batch_args([str(pdf), "40", "--mode", "marker", "--mock", "--out", str(outdir), "--images"], env={})
+    res = run_batch_args(
+        [str(pdf), "40", "--mode", "marker", "--mock", "--out", str(outdir), "--images"], env={}
+    )
     assert res.returncode == 0, res.stdout
     assert (outdir / "c.md").exists()
 
@@ -54,10 +57,13 @@ def test_slice_backoff_with_mock_threshold(tmp_path: Path):
     pdf = tmp_path / "d.pdf"
     make_blank_pdf(pdf)
     # Start with large slice, fail slices > 10, expect backoff to <=10 and succeed
-    res = run_batch_args([str(pdf), "40"], env={
-        "SMART_PDF_MD_MARKER_MOCK": "1",
-        "SMART_PDF_MD_MOCK_FAIL_IF_SLICE_GT": "10",
-        # Ensure we are on marker path (blank pdf should route there automatically)
-    })
+    res = run_batch_args(
+        [str(pdf), "40"],
+        env={
+            "SMART_PDF_MD_MARKER_MOCK": "1",
+            "SMART_PDF_MD_MOCK_FAIL_IF_SLICE_GT": "10",
+            # Ensure we are on marker path (blank pdf should route there automatically)
+        },
+    )
     assert res.returncode == 0, res.stdout
     assert (tmp_path / "d.md").exists()

--- a/tests/test_cli_and_paths_more.py
+++ b/tests/test_cli_and_paths_more.py
@@ -6,6 +6,7 @@ from pathlib import Path
 def ensure_pymupdf():
     try:
         import importlib.util  # noqa: F401
+
         if importlib.util.find_spec("fitz") is None:
             raise ImportError
     except Exception:
@@ -62,10 +63,13 @@ def test_first_nonzero_exitcode_selected(tmp_path: Path):
     make_text_pdf(good, "Some Text")
     bad.write_bytes(b"%PDF-1.4\n% not actually valid content")  # unopenable -> single-pass
 
-    res = run_script([str(tmp_path), "40"], env={
-        "SMART_PDF_MD_MARKER_MOCK": "1",
-        "SMART_PDF_MD_MARKER_MOCK_FAIL": "1",  # fail marker always
-    })
+    res = run_script(
+        [str(tmp_path), "40"],
+        env={
+            "SMART_PDF_MD_MARKER_MOCK": "1",
+            "SMART_PDF_MD_MARKER_MOCK_FAIL": "1",  # fail marker always
+        },
+    )
     # First non-zero will come from the first file that routes to marker and fails at min-slice/single-pass
     assert res.returncode in (2, 3)
 
@@ -77,11 +81,14 @@ def test_cli_min_chars_and_ratio_force_fast(tmp_path: Path):
     # Create a valid, but effectively blank, PDF
     ensure_pymupdf()
     import fitz  # type: ignore
+
     doc = fitz.open()
     doc.new_page()
     doc.save(pdf)
     doc.close()
     # Heuristic flags should push to fast path even with no text
-    res = run_script([str(pdf), "40", "--min-chars", "1", "--min-ratio", "0", "--mode", "auto"], env={})
+    res = run_script(
+        [str(pdf), "40", "--min-chars", "1", "--min-ratio", "0", "--mode", "auto"], env={}
+    )
     assert res.returncode == 0
     assert md.exists()

--- a/tests/test_config_features.py
+++ b/tests/test_config_features.py
@@ -7,6 +7,7 @@ from pathlib import Path
 def ensure_pymupdf():
     try:
         import importlib.util  # noqa: F401
+
         if importlib.util.find_spec("fitz") is None:
             raise ImportError
     except Exception:
@@ -34,7 +35,9 @@ def make_blank_pdf(path: Path) -> None:
     doc.close()
 
 
-def run_batch(input_path: Path, *, env: dict | None = None, slice_pages: int = 40) -> subprocess.CompletedProcess:
+def run_batch(
+    input_path: Path, *, env: dict | None = None, slice_pages: int = 40
+) -> subprocess.CompletedProcess:
     root = Path(__file__).resolve().parents[1]
     if os.name == "nt":
         script = root / "smart-pdf-md.bat"
@@ -54,7 +57,9 @@ def test_output_dir_fast_mode(tmp_path: Path):
     pdf = tmp_path / "x.pdf"
     outdir = tmp_path / "out"
     make_text_pdf(pdf)
-    result = run_batch(pdf, env={"SMART_PDF_MD_MODE": "fast", "SMART_PDF_MD_OUTPUT_DIR": str(outdir)})
+    result = run_batch(
+        pdf, env={"SMART_PDF_MD_MODE": "fast", "SMART_PDF_MD_OUTPUT_DIR": str(outdir)}
+    )
     assert result.returncode == 0, result.stdout
     md = outdir / "x.md"
     assert md.exists(), "Output not written to custom outdir"
@@ -64,5 +69,7 @@ def test_mock_marker_failure_sets_nonzero_exit(tmp_path: Path):
     """Mocked marker failure should produce a non-zero exit in auto routing."""
     pdf = tmp_path / "y.pdf"
     make_blank_pdf(pdf)
-    result = run_batch(pdf, env={"SMART_PDF_MD_MARKER_MOCK": "1", "SMART_PDF_MD_MARKER_MOCK_FAIL": "1"})
+    result = run_batch(
+        pdf, env={"SMART_PDF_MD_MARKER_MOCK": "1", "SMART_PDF_MD_MARKER_MOCK_FAIL": "1"}
+    )
     assert result.returncode != 0, "Expected non-zero exit when mock marker fails"

--- a/tests/test_exit_and_heuristics.py
+++ b/tests/test_exit_and_heuristics.py
@@ -7,6 +7,7 @@ from pathlib import Path
 def ensure_pymupdf():
     try:
         import importlib.util  # noqa: F401
+
         if importlib.util.find_spec("fitz") is None:
             raise ImportError
     except Exception:
@@ -52,10 +53,13 @@ def test_heuristics_force_fast_on_blank_pdf(tmp_path: Path):
     md = tmp_path / "blank.md"
     make_blank_pdf(pdf)
     # Default heuristic would route to marker; lower the ratio to 0 to force "textual"
-    res = run_script([str(pdf), "40"], env={
-        "SMART_PDF_MD_TEXT_MIN_RATIO": "0",
-        "SMART_PDF_MD_MODE": "auto",
-    })
+    res = run_script(
+        [str(pdf), "40"],
+        env={
+            "SMART_PDF_MD_TEXT_MIN_RATIO": "0",
+            "SMART_PDF_MD_MODE": "auto",
+        },
+    )
     assert res.returncode == 0
     assert md.exists(), "Fast path should write an md even for blank (empty content)"
 
@@ -65,8 +69,11 @@ def test_min_slice_failure_exit2(tmp_path: Path):
     pdf = tmp_path / "scan.pdf"
     make_blank_pdf(pdf, pages=7)
     # With mock, fail any slice > 4; initial slice 5 triggers min-slice failure when cur=5
-    res = run_script([str(pdf), "5"], env={
-        "SMART_PDF_MD_MARKER_MOCK": "1",
-        "SMART_PDF_MD_MOCK_FAIL_IF_SLICE_GT": "4",
-    })
+    res = run_script(
+        [str(pdf), "5"],
+        env={
+            "SMART_PDF_MD_MARKER_MOCK": "1",
+            "SMART_PDF_MD_MOCK_FAIL_IF_SLICE_GT": "4",
+        },
+    )
     assert res.returncode == 2

--- a/tests/test_fast_path.py
+++ b/tests/test_fast_path.py
@@ -7,6 +7,7 @@ from pathlib import Path
 def ensure_pymupdf():
     try:
         import importlib.util  # noqa: F401
+
         if importlib.util.find_spec("fitz") is None:
             raise ImportError
     except Exception:
@@ -24,7 +25,9 @@ def make_text_pdf(path: Path, text: str = "Hello from smart-pdf-md") -> None:
     doc.close()
 
 
-def run_batch(input_path: Path, *, env: dict | None = None, slice_pages: int = 40) -> subprocess.CompletedProcess:
+def run_batch(
+    input_path: Path, *, env: dict | None = None, slice_pages: int = 40
+) -> subprocess.CompletedProcess:
     root = Path(__file__).resolve().parents[1]
     if os.name == "nt":
         script = root / "smart-pdf-md.bat"

--- a/tests/test_marker_paths.py
+++ b/tests/test_marker_paths.py
@@ -7,6 +7,7 @@ from pathlib import Path
 def ensure_pymupdf():
     try:
         import importlib.util  # noqa: F401
+
         if importlib.util.find_spec("fitz") is None:
             raise ImportError
     except Exception:
@@ -23,7 +24,9 @@ def make_blank_pdf(path: Path) -> None:
     doc.close()
 
 
-def run_batch(input_path: Path, *, env: dict | None = None, slice_pages: int = 40) -> subprocess.CompletedProcess:
+def run_batch(
+    input_path: Path, *, env: dict | None = None, slice_pages: int = 40
+) -> subprocess.CompletedProcess:
     root = Path(__file__).resolve().parents[1]
     if os.name == "nt":
         script = root / "smart-pdf-md.bat"


### PR DESCRIPTION
## Summary
- document code style, required checks, commit conventions, and cross-platform guidance
- rename contribution guide to `agents.md`
- format tests and replace shell script dependency checks to fix syntax errors

## Testing
- `ruff check`
- `ruff format --check`
- `pytest -q` *(hangs: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68bb358c251483259e1292d027d2029f