### PR TITLE
chore: broaden ruff source paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.ruff]
 target-version = "py311"
 line-length = 100
-src = ["tests"]
+src = [".", "tests"]
 exclude = [
   ".git",
   "__pycache__",


### PR DESCRIPTION
## Summary
- lint root-level scripts by including repository root in Ruff's source paths

## Testing
- `shellcheck smart-pdf-md.sh`
- `shellcheck smart-pdf-md.bat` *(fails: Tips depend on target shell...)*
- `ruff check`
- `ruff format --check`
- `pytest -q -rA`


------
https://chatgpt.com/codex/tasks/task_e_68bc38ba8fa48325b0d76e7a94eba780