### PR TITLE
fix: close PyMuPDF document before marker slices

### DIFF
--- a/smart_pdf_md_driver.py
+++ b/smart_pdf_md_driver.py
@@ -121,6 +121,7 @@ def marker_convert(pdf, outdir, slice_pages):
         log("[OK   ] single-pass done")
         return 0
     total = len(doc)
+    doc.close()
     start = 0
     cur = int(slice_pages)
     log(f"[MRK_S] total_pages={total} slice={cur} dpi={LOWRES}/{HIGHRES}")


### PR DESCRIPTION
## Summary
- close PyMuPDF document before launching marker slices to avoid locked file errors

## Testing
- `python -m ruff check`
- `python -m ruff format --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc904430088325827269c7925613cc