### PR TITLE
fix: propagate convert_text failure in driver

### DIFF
--- a/smart_pdf_md_driver.py
+++ b/smart_pdf_md_driver.py
@@ -164,15 +164,13 @@ def process_one(pdf, idx, total, slice_pages):
     try:
         if MODE == "fast":
             log("[path ] FORCED FAST -> PyMuPDF")
-            convert_text(str(pdf), str(outdir))
-            return 0
+            return convert_text(str(pdf), str(outdir))
         if MODE == "marker":
             log("[path ] FORCED MARKER -> marker_single")
             return marker_convert(str(pdf), str(outdir), slice_pages)
         if is_textual(str(pdf)):
             log("[path ] TEXTUAL -> fast PyMuPDF")
-            convert_text(str(pdf), str(outdir))
-            return 0
+            return convert_text(str(pdf), str(outdir))
         log("[path ] NON-TEXTUAL -> marker_single")
         return marker_convert(str(pdf), str(outdir), slice_pages)
     except Exception as e:


### PR DESCRIPTION
## Summary
- propagate convert_text return code so failures bubble up

## Testing
- `ruff check`
- `ruff format --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bca9d65d488325870e0d978990e9b0