### PR TITLE
ci: add format and build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,10 +175,10 @@ PY
         with:
           python-version: '3.11'
           cache: 'pip'
-      - name: Install PyInstaller
+      - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install pyinstaller
+          python -m pip install pyinstaller pymupdf marker-pdf
       - name: Build binary
         run: |
           pyinstaller smart_pdf_md_driver.py --onefile -n smart-pdf-md


### PR DESCRIPTION
## Summary
- add ruff formatting check
- build standalone binaries with PyInstaller across platforms
- bundle runtime dependencies in build job

## Testing
- `python -m ruff check`
- `python -m ruff format --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcbbc7fd888325a8364f16bc6e5c52