### PR TITLE
fix: use real python interpreter for marker fallback

### DIFF
--- a/smart_pdf_md_driver.py
+++ b/smart_pdf_md_driver.py
@@ -39,7 +39,26 @@ def mock_write_markdown(pdf, outdir, note):
 
 def which_marker_single():
     p = shutil.which("marker_single")
-    return [p] if p else [sys.executable, "-m", "marker.scripts.convert_single"]
+    if p:
+        return [p]
+    if getattr(sys, "frozen", False):
+        env = os.environ.get("SMART_PDF_MD_PYTHON")
+        candidates = [env] if env else []
+        base = getattr(sys, "_base_executable", None)
+        if base and Path(base).exists():
+            candidates.append(base)
+        exe = Path(sys.executable)
+        candidates += [
+            shutil.which("python3"),
+            shutil.which("python"),
+            shutil.which("py"),
+            exe.with_name("python"),
+            exe.with_name("python3"),
+        ]
+        for c in candidates:
+            if c and Path(c).exists():
+                return [str(c), "-m", "marker.scripts.convert_single"]
+    return [sys.executable, "-m", "marker.scripts.convert_single"]
 
 
 def try_open(pdf):


### PR DESCRIPTION
## Summary
- search for a real Python interpreter when marker_single is missing in PyInstaller builds

## Testing
- `python -m ruff check`
- `python -m ruff format --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcc1271608832589112e74bcfededf