### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install pyinstaller pymupdf marker-pdf
+      - name: Build binary
+        run: |
+          pyinstaller smart_pdf_md_driver.py --onefile -n smart-pdf-md
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: smart-pdf-md-${{ matrix.os }}
+          path: dist/smart-pdf-md*
+
+  release:
+    name: Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: smart-pdf-md-*
+          path: dist
+          merge-multiple: true
+      - name: Set version
+        id: vars
+        run: echo "version=v$(date +'%Y%m%d')-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+      - name: Create tag
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git tag ${{ steps.vars.outputs.version }}
+          git push origin ${{ steps.vars.outputs.version }}
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.vars.outputs.version }}
+          name: ${{ steps.vars.outputs.version }}
+          files: dist/smart-pdf-md-*


### PR DESCRIPTION
## Summary
- add workflow to build binaries, tag version, and publish GitHub releases

## Testing
- `python -m ruff check`
- `python -m ruff format --check`
- `SMART_PDF_MD_MARKER_MOCK=1 pytest -q` *(failed: hung, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68be9bb247c88325bcf43de410e27c20